### PR TITLE
Fix cupy type mapping bug

### DIFF
--- a/python/cutlass/utils/datatypes.py
+++ b/python/cutlass/utils/datatypes.py
@@ -102,7 +102,7 @@ def numpy_type(inp):
 
 
 def is_cupy_available():
-    global cupy_available
+    global cupy_available, _library_to_cupy_dict
     if cupy_available is None:
         try:
             import cupy as cp

--- a/test/python/cutlass/utils/run_all_tests.py
+++ b/test/python/cutlass/utils/run_all_tests.py
@@ -1,0 +1,11 @@
+import pathlib
+import unittest
+
+if __name__ == '__main__':
+    loader = unittest.TestLoader()
+    script_dir = str(pathlib.Path(__file__).parent.resolve()) + '/'
+    tests = loader.discover(script_dir, 'test_*.py')
+    testRunner = unittest.runner.TextTestRunner()
+    results = testRunner.run(tests)
+    if not results.wasSuccessful():
+        raise Exception('Test cases failed')

--- a/test/python/cutlass/utils/test_datatypes.py
+++ b/test/python/cutlass/utils/test_datatypes.py
@@ -1,0 +1,14 @@
+import unittest
+import cutlass
+from cutlass.utils import datatypes
+
+class CupyTypeTest(unittest.TestCase):
+    def test_cupy_type_initialized_after_availability_check(self):
+        if not datatypes.is_cupy_available():
+            self.skipTest("cupy not available")
+        import cupy as cp
+        dt = datatypes.cupy_type(cutlass.DataType.f32)
+        self.assertEqual(dt, cp.float32)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix is_cupy_available to correctly update global dictionary
- add unittest for datatypes.cupy_type

## Testing
- `PYTHONPATH=python python test/python/cutlass/utils/run_all_tests.py` *(fails: ModuleNotFoundError: No module named 'numpy')*